### PR TITLE
Copy fonts

### DIFF
--- a/config/gulp/copy.js
+++ b/config/gulp/copy.js
@@ -2,6 +2,9 @@ import gulp from 'gulp';
 
 export default () => {
     return gulp
-        .src(['source/*.{ico,icns,txt}'])
+        .src([
+            'source/*.{ico,icns,txt}',
+            'source/**/*-Regular.ttf',
+        ])
         .pipe(gulp.dest('public'));
 }


### PR DESCRIPTION
This adds a little bit of config to the copy task that makes it also copy the "Regular" weight of any fonts in the assets folder into their respective folders in the public/build directory.

#### How to test

1. Checkout this branch with `git checkout mysterycommand/copy-fonts`
2. Run the build command with `npm run build`
3. Verify that the fonts are copied into the `public` folder (generated by the build commend) at `/public/assets/faunaone/FaunaOne-Regular.ttf` and `/public/assets/playfairdisplay/PlayfairDisplay-Regular.ttf`
… I'm pretty sure these are the only weights of these fonts you're using.
4. Double check that the fonts load and everything looks right when you open `/public/index.html` in your browser.

If all that works, go ahead and merge this and then as an extra testing measure go ahead and check that the staging site (https://potpiedigital.github.io/poetspetparlor.com/staging/6/) is updated and can load the fonts as expected.