### PR TITLE
Copy all kinds of fonts

### DIFF
--- a/config/gulp/copy.js
+++ b/config/gulp/copy.js
@@ -4,7 +4,7 @@ export default () => {
     return gulp
         .src([
             'source/*.{ico,icns,txt}',
-            'source/**/*-Regular.ttf',
+            'source/**/*.{eot,otf,ttf,svg,woff,woff2}',
         ])
         .pipe(gulp.dest('public'));
 }

--- a/source/stylesheet.css
+++ b/source/stylesheet.css
@@ -10,14 +10,16 @@
 
 @font-face {
     font-family: 'oswaldregular';
-    src: url('./assets/webfontkit/oswald-regular-webfont.woff2') format('woff2'), url('./assets/webfontkit/oswald-regular-webfont.woff') format('woff');
+    src: url('./assets/webfontkit/oswald-regular-webfont.woff2') format('woff2'),
+         url('./assets/webfontkit/oswald-regular-webfont.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'open_sansregular';
-    src: url('./assets/webfontkit/opensans-regular-webfont.woff2') format('woff2'), url('./assets/webfontkit/opensans-regular-webfont.woff') format('woff');
+    src: url('./assets/webfontkit/opensans-regular-webfont.woff2') format('woff2'),
+         url('./assets/webfontkit/opensans-regular-webfont.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 }


### PR DESCRIPTION
@Purple906, this should update the copy script to copy any kind of font file you add in the future. Is that `@font-face` rule the one Font Squirrel gave you? I'm surprised that WOFF and WOFF2 are the only kinds it's using, but maybe older browsers have finally caught up.

Anyway, this update should copy any EOT, OTF, TTF, SVG, WOFF, WOFF2 files that it finds. One thing I notice is that the build step takes a long time because it's processing a bunch of image and font files that it looks like it's not using anymore? Might be time to clean some of that up.